### PR TITLE
Add github workflow for dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+# for the future
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 # for the future
 updates:
-  - package-ecosystem: maven
+  - package-ecosystem: gradle
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Related Issue

- we want to know about known vulnerabilities in our dependencies

## Changes Proposed

- use github's dependabot to periodically scan the project